### PR TITLE
(feat) Add CommonUtils to support rules referencing concepts

### DIFF
--- a/api/src/main/java/org/openmrs/module/drools/api/DroolsEngineService.java
+++ b/api/src/main/java/org/openmrs/module/drools/api/DroolsEngineService.java
@@ -48,7 +48,7 @@ public interface DroolsEngineService extends OpenmrsService {
 	 * @param <T>     the type of objects to retrieve
 	 * @param session the Drools session to query
 	 * @param tClass  the class object representing the type to retrieve
-	 * @return List<T> a list of objects of the specified type from the session
+	 * @return a list of objects of the specified type from the session
 	 * @throws DroolsSessionException if the session does not exist or cannot be
 	 *                                accessed
 	 */
@@ -62,7 +62,7 @@ public interface DroolsEngineService extends OpenmrsService {
 	 * @param session    the Drools session to query
 	 * @param tClass     the class object representing the type to retrieve
 	 * @param tPredicate the predicate that returned objects must satisfy
-	 * @return List<T> a list of matching objects from the session
+	 * @return a list of matching objects from the session
 	 * @throws DroolsSessionException if the session does not exist or cannot be
 	 *                                accessed
 	 */

--- a/api/src/main/java/org/openmrs/module/drools/calculation/DroolsCalculationService.java
+++ b/api/src/main/java/org/openmrs/module/drools/calculation/DroolsCalculationService.java
@@ -24,6 +24,7 @@ public interface DroolsCalculationService {
      *
      * // Check if most recent diagnosis equals a specific concept
      * checkMostRecentObs(patient, "CIEL:1284", Operator.EQUALS, "CIEL:5622");
+     * }</pre>
      *
      * @param patient the patient whose observations will be evaluated; must not be null
      * @param conceptRef the concept reference (UUID or mapping)

--- a/api/src/main/java/org/openmrs/module/drools/utils/DroolsDateUtils.java
+++ b/api/src/main/java/org/openmrs/module/drools/utils/DroolsDateUtils.java
@@ -119,7 +119,7 @@ public class DroolsDateUtils {
     }
 
     /**
-     * Checks if the difference between start and end is >= threshold in given granularity.
+     * Checks if the difference between start and end is at least the threshold in given granularity.
      *
      * @param start the start date
      * @param end the end date
@@ -158,7 +158,7 @@ public class DroolsDateUtils {
      * @param start the start date
      * @param end the end date
      * @param granularity the granularity
-     * @return the difference (end - start) in given units, negative if end < start
+     * @return the difference (end - start) in given units, negative if end is before start
      */
     public static long diff(Date start, Date end, Granularity granularity) {
         if (start == null || end == null || granularity == null) {

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -21,4 +21,6 @@
   		    http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
 	<context:component-scan base-package="org.openmrs.module.drools.web.controller" />
+	<context:component-scan base-package="org.openmrs.module.drools.loader" />
+	<context:component-scan base-package="org.openmrs.module.drools.provider" />
 </beans>


### PR DESCRIPTION
This adds a couple functions to CommonUtils so that rules can be written like

```
Concept systolicConcept = Context.getConceptService().getConceptByMapping("5085", "CIEL");
```

Also fix some JavaDoc problems and register a couple beans (I forget why this was needed).