### PR TITLE
(chore) Try to fix release by setting force-clean-build to true

### DIFF
--- a/bamboo-specs/bamboo.yml
+++ b/bamboo-specs/bamboo.yml
@@ -61,12 +61,12 @@ Release to Maven:
   key: RTM
   tasks:
     - checkout:
-        force-clean-build: 'false'
+        force-clean-build: 'true'
         description: Checkout Default Repository
     - checkout:
         repository: Release scripts
         path: release-scripts
-        force-clean-build: 'false'
+        force-clean-build: 'true'
         description: Checkout Release Scripts Repository
     - script:
         interpreter: SHELL


### PR DESCRIPTION
Release is presently broken: https://ci.openmrs.org/browse/DM-DM-RTM-10/log

Release job uses Docker, but the checkout isn't working.